### PR TITLE
Extend whitespace control

### DIFF
--- a/pint.json
+++ b/pint.json
@@ -79,10 +79,13 @@
         "phpdoc_trim_consecutive_blank_line_separation": true,
         "psr_autoloading": true,
         "single_line_comment_spacing": true,
+        "single_space_around_construct": true,
         "single_quote": true,
+        "space_after_semicolon": true,
         "ternary_to_null_coalescing": true,
         "trailing_comma_in_multiline": true,
         "trim_array_spaces": true,
-        "type_declaration_spaces": true
+        "type_declaration_spaces": true,
+        "types_spaces": true
     }
 }


### PR DESCRIPTION
Extend rule set
- [single_space_around_construct](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.38|fixer:single_space_around_construct)
- [space_after_semicolon](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.38|fixer:space_after_semicolon)
- [types_spaces](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.38|fixer:types_spaces)