### PR TITLE
Configure .editorconfig, .gitattributes, update README, require latest Pint version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,13 +3,10 @@ root = true
 [*]
 charset = utf-8
 end_of_line = lf
-insert_final_newline = true
-indent_style = space
 indent_size = 4
+indent_style = space
+insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.json]
-insert_final_newline = false
 
 [*.md]
 trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+* text=auto eol=lf
+
+*.json text diff=json
+*.md text diff=markdown
+
+# Ignore for export
+/.git export-ignore
+/.idea export-ignore
+
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/composer.lock export-ignore

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 # The MIT License (MIT)
 
-Copyright (c) 2023 portavice GmbH
+Copyright (c) 2023-2025 portavice GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@
 [![Latest version on Packagist](https://img.shields.io/packagist/v/portavice/laravel-pint-config.svg)](https://packagist.org/packages/portavice/laravel-pint-config)
 [![Total downloads](https://img.shields.io/packagist/dt/portavice/laravel-pint-config.svg)](https://packagist.org/packages/portavice/laravel-pint-config)
 
-This projects contains the default configuration for [Laravel Pint](https://laravel.com/docs/10.x/pint#configuring-pint)
+This project contains the default configuration for [Laravel Pint](https://laravel.com/docs/12.x/pint#configuring-pint)
 used at portavice GmbH.
+
+The ruleset is based on [PSR12](https://cs.symfony.com/doc/ruleSets/PSR12.html) with additional rules for
+
+- ordered class elements, imports, used interfaces and traits, parameter types,
+- short syntax, proper indentation, trailing commas for arrays,
+- consistent braces, operators, spacing, blank lines, 
+- preferring single quotes,
+- and avoiding useless code (`else`, `return`, `sprintf`, empty statements).
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Laravel Pint configuration used at portavice",
     "type": "library",
     "require": {
-        "laravel/pint": "^1.13"
+        "laravel/pint": "^1.25"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
- Adjust `.editorconfig` such that it fits to current JSON files
- Define `export-ignore` in `.gitattributes`
- Update copyright year in license file
- Add description of the ruleset in `README`
- Require Laravel Pint 1.25+